### PR TITLE
Switch to generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,32 @@
-# asdf-erlang-prebuilt-ubuntu-22.04
+# asdf-erlang-prebuilt-ubuntu
 
-Erlang plugin for [asdf](https://github.com/asdf-vm/asdf) version manager, using Erlang builds by [hexpm/bob](https://github.com/hexpm/bob), for ubuntu versions from 22.04 to 23.10
+Erlang plugin for [asdf](https://github.com/asdf-vm/asdf) version manager, using Erlang builds by [hexpm/bob](https://github.com/hexpm/bob), for ubuntu. Attempts to auto determine the release (18.04, 20.04, 22.04, 24.04, etc) as well as the system architecture (arm64/amd64) to install the correct one for the platform.
+
+NOTE: `lsb_release` is used to perform automatic detection of ubuntu release
+NOTE: `dpkg --print-architecture` is used to perform automatic detection of system architecture
+
+You can override the ARCH, or Ubuntu versions (via `ImageOS`) by specifying an environment flag at `asdf install erlang ...` with the following flags:
+* ImageOS
+* ARCH
+
+| ImageOS  | Operating system
+|-         |-
+| ubuntu18 | ubuntu-18.04
+| ubuntu20 | ubuntu-20.04
+| ubuntu22 | ubuntu-22.04
+| ubuntu24 | ubuntu-24.04
+
+ImageOS was selected as the environment variable to be consistent with https://github.com/erlef/setup-beam
+
+| ARCH  
+|-         
+| amd64 
+| arm64 
+
+e.g. `ImageOS=ubuntu24 ARCH=amd64 asdf install erlang 26.2.5` will use the precompiled BOB build from `https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/OTP-26.2.5.tar.gz`. 
 
 ## Install
 
 ```
-asdf plugin-add erlang https://github.com/michallepicki/asdf-erlang-prebuilt-ubuntu-22.04.git
+asdf plugin-add erlang https://github.com/cranksecurity/asdf-erlang-prebuilt-ubuntu.git
 ```

--- a/bin/install
+++ b/bin/install
@@ -79,7 +79,30 @@ get_download_url_for_version() {
     version="OTP-${version}"
   fi
 
-  echo "https://builds.hex.pm/builds/otp/ubuntu-22.04/${version}.tar.gz"
+  if [ -x "$(command -v lsb_release)" ]; then
+    ubuntu_release=$(lsb_release -rs)
+  fi
+
+  if [ -x "$(command -v dpkg)" ]; then
+    arch=$(dpkg --print-architecture)
+  fi
+
+  if [[ -v ARCH ]]; then
+    arch=${ARCH}
+  fi
+
+  if [[ -v ImageOS ]]; then
+    if [[ "$ImageOS" =~ ^ubuntu([0-9]{2})$ ]]; then
+      ubuntu_release="${BASH_REMATCH[1]}.04"
+    else
+      cat <<EOS
+==> ImageOS environment variable didn't match expected format of ubuntuXY where xy is the ubuntu version number (22,24,etc)
+EOS
+      exit 1
+    fi
+  fi
+  
+  echo "https://builds.hex.pm/builds/otp/${arch}/ubuntu-${ubuntu_release}/${version}.tar.gz"
 }
 
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -25,7 +25,7 @@ EOS
     fi
   fi
   
-  local releases_url='https://builds.hex.pm/builds/otp/${arch}/ubuntu-${ubuntu_release}/builds.txt'
+  local releases_url="https://builds.hex.pm/builds/otp/${arch}/ubuntu-${ubuntu_release}/builds.txt"
 
   if ! curl -fs $releases_url; then
     cat >&2 <<EOS

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,7 +1,31 @@
 #!/usr/bin/env bash
 
 download_hex_pm_builds() {
-  local releases_url='https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt'
+
+  if [ -x "$(command -v lsb_release)" ]; then
+    ubuntu_release=$(lsb_release -rs)
+  fi
+
+  if [ -x "$(command -v dpkg)" ]; then
+    arch=$(dpkg --print-architecture)
+  fi
+
+  if [[ -v ARCH ]]; then
+    arch=${ARCH}
+  fi
+
+  if [[ -v ImageOS ]]; then
+    if [[ "$ImageOS" =~ ^ubuntu([0-9]{2})$ ]]; then
+      ubuntu_release="${BASH_REMATCH[1]}.04"
+    else
+      cat <<EOS
+==> ImageOS environment variable didn't match expected format of ubuntuXY where xy is the ubuntu version number (22,24,etc)
+EOS
+      exit 1
+    fi
+  fi
+  
+  local releases_url='https://builds.hex.pm/builds/otp/${arch}/ubuntu-${ubuntu_release}/builds.txt'
 
   if ! curl -fs $releases_url; then
     cat >&2 <<EOS


### PR DESCRIPTION
Enables a dynamic lookup of the OS and Architecture allowing for simpler use of ASDF across AMD64/ARM64 as well as future proofing ubuntu support.

BUT - it doesn't work with non LTS releases - but that can be handled by specifying an imageOS.